### PR TITLE
Avoid ioctl error when stdin is not a terminal

### DIFF
--- a/tee_output/__init__.py
+++ b/tee_output/__init__.py
@@ -85,9 +85,10 @@ def _tee(src, to, stdout):
     if src.isatty():
         tty.setraw(r)
 
-        # Copy window size
-        packed = fcntl.ioctl(sys.stdin, termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0))
-        fcntl.ioctl(r, termios.TIOCSWINSZ, packed)
+        if sys.stdin.isatty():
+            # Copy window size
+            packed = fcntl.ioctl(sys.stdin, termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0))
+            fcntl.ioctl(r, termios.TIOCSWINSZ, packed)
 
         def set_ctty():
             signal.signal(signal.SIGINT, signal.SIG_IGN)


### PR DESCRIPTION
When teeing an output stream, if that stream is a tty, _tee attempts to copy the window size from stdin. But there is no guarantee that stdin is also a tty, so we need to check it separately.

This problem was encountered when using tee-output in a Jupyter notebook environment. In some circumstances, the stdout file descriptor is detected as a tty (`os.isatty(sys.stdout.fileno()) == True`), even if `sys.stdout` isn't. When tee-output dups the file descriptor, the duplicate is also a tty, as well as the stream built from it (`os.fdopen(os.dup(sys.stdout.fileno()), "rb", buffering=0).isatty() == True`); but sys.stdin is still not a tty, and trying use TIOCGWINSZ on it produces `ENOTTY`).